### PR TITLE
Fix: Correct JS dependency registration for TYPO3 v13 compatibility

### DIFF
--- a/Classes/Form/Elements/AnimationPreviewField.php
+++ b/Classes/Form/Elements/AnimationPreviewField.php
@@ -278,13 +278,14 @@ class AnimationPreviewField extends AbstractFormElement
         );
         $animationDefinitionsWebPath = PathUtility::getAbsoluteWebPath($animationDefinitionsPath);
 
-        $pageRenderer->addJsFooterFile(
-            $animationDefinitionsWebPath,
+        $pageRenderer->addJsFooterLibrary(
+            'content_gsap_animation_definitions', // Key
+            $animationDefinitionsWebPath,          // Path
             'text/javascript',
             false,  // $compress
             false,  // $forceOnTop
             '',     // $allWrap
-            false,  // $excludeFromConcatenation
+            true,   // $typo3PageModuleRelevant
             '|defer', // $additionalAttributes
             false,  // $enableAsyncInES6Modules
             'gsap_scrolltrigger' // $dependencies
@@ -296,16 +297,17 @@ class AnimationPreviewField extends AbstractFormElement
         );
         $previewWebPath = PathUtility::getAbsoluteWebPath($previewPath);
 
-        $pageRenderer->addJsFooterFile(
-            $previewWebPath,
+        $pageRenderer->addJsFooterLibrary(
+            'content_gsap_animation_preview_bundle', // Key
+            $previewWebPath,                         // Path
             'text/javascript',
             false, // $compress
             false, // $forceOnTop
             '',    // $allWrap
-            false, // $excludeFromConcatenation
+            true,  // $typo3PageModuleRelevant
             '|defer', // $additionalAttributes
             false, // $enableAsyncInES6Modules
-            PathUtility::getFileNameWithoutExtension($animationDefinitionsWebPath) // $dependencies
+            'content_gsap_animation_definitions' // $dependencies
         );
 
         return $result;


### PR DESCRIPTION
Corrects an error `Call to undefined method TYPO3\CMS\Core\Utility\PathUtility::getFileNameWithoutExtension()` that occurred in the backend.

The error was caused by an incorrect attempt to generate a dependency key using `PathUtility::getFileNameWithoutExtension()`, which is unavailable in TYPO3 v12+.

The fix involves:
- Switching from `addJsFooterFile` to `addJsFooterLibrary` for including `animation-definitions.js` and `preview.bundle.js` via PageRenderer in `AnimationPreviewField.php`.
- Using explicit, unique string keys for these libraries.
- Setting the dependency for `preview.bundle.js` to the key of `animation-definitions.js` directly, removing the erroneous method call.

This ensures correct JavaScript loading order and resolves the compatibility issue with newer TYPO3 versions.